### PR TITLE
Update compat for PlutoSliderServer to 1.0.0

### DIFF
--- a/evaluation/flake.nix
+++ b/evaluation/flake.nix
@@ -14,7 +14,7 @@
           julia -e 'using Pkg
             Pkg.activate(mktempdir())
             Pkg.add([
-              Pkg.PackageSpec(name="PlutoSliderServer", version="0.3.2-0.3"),
+              Pkg.PackageSpec(name="PlutoSliderServer", version="1"),
             ])
 
             import PlutoSliderServer


### PR DESCRIPTION
Hi! This is an automatic PR to update the PlutoSliderServer compat from 0.3 to 1.0.0! I did not test this PR, but PlutoSliderServer 1.0.0 had no breaking changes, except the new Julia 1.10 minimum ([release notes](https://github.com/JuliaPluto/PlutoSliderServer.jl/releases/tag/v1.0.0)). 